### PR TITLE
support GitHub flavored Markdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN apt-get update && apt-get install -y \
     libicu-dev \
     libz-dev \
     ruby \
-    ruby-dev
+    ruby-dev && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists
 
 # install gollum & GitHub Flavored Markdown
 RUN gem install gollum github-markdown

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y \
     ruby \
     ruby-dev
 
-# install gollum
-RUN gem install gollum
+# install gollum & GitHub Flavored Markdown
+RUN gem install gollum github-markdown
 
 # initialize wiki content
 RUN mkdir /root/wiki && \


### PR DESCRIPTION
The existing installation does not support the custom extensions by
GitHub to Markdown such as tables.
